### PR TITLE
Fix add_config variable init

### DIFF
--- a/core/functions.sh
+++ b/core/functions.sh
@@ -55,7 +55,10 @@ prepend_string_to_file() {
 }
 line_exists() { grep -qFx "$1" "$2"; }
 add_config() {
-  local file="$1" path="$2" content="$3" cfg="$path/$file"
+  local file="$1"
+  local path="$2"
+  local content="$3"
+  local cfg="$path/$file"
   mkdir -p "$path"
   if [[ -f "$cfg" ]]; then
     while IFS= read -r line; do


### PR DESCRIPTION
## Summary
- separate local variable initialization in `add_config`

## Testing
- `shellcheck -x core/functions.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fee26ec808328aaf693c79823f55d